### PR TITLE
fix: burn down ShellCheck baseline in core CLI (#8)

### DIFF
--- a/commands/proxy.sh
+++ b/commands/proxy.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-# shellcheck disable=SC2046,SC2086,SC2124,SC2155,SC2181
-# Pre-existing findings baselined for incremental ShellCheck adoption — see #8.
 
 #######################################################################################
 # BEGIN: utilities from https://github.com/montoyaedu/Trish/blob/master/test_tools.sh #
@@ -17,8 +15,9 @@ function debug {
 }
 
 function is {
-    local -r actual=$(read_input)
-    local -r expected="${@}"
+    local actual
+    actual=$(read_input)
+    local expected="$*"
     if [ "${actual}" == "${expected}" ]; then
         return 0
     else
@@ -77,7 +76,8 @@ function __easy_command_proxy {
   return $?
  fi
  if [[ "certbot" == "$2" ]]; then
-  local EASY_PROXY=$(easy proxy status)
+  local EASY_PROXY
+  EASY_PROXY=$(easy proxy status)
   if [[ -z "${EASY_PROXY}" ]]; then
    echo "Proxy is not running."
    return 1
@@ -90,11 +90,12 @@ function __easy_command_proxy {
    echo "Invalid Domain. Set environment variable EASY_LETSENCRYPT_DOMAIN"
    return 1
   fi
-  docker exec -it "${EASY_PROXY}" sudo certbot --email ${EASY_LETSENCRYPT_EMAIL} --agree-tos --manual-public-ip-logging-ok certonly --manual --preferred-challenges dns -d "${EASY_LETSENCRYPT_DOMAIN},*.${EASY_LETSENCRYPT_DOMAIN}"
+  docker exec -it "${EASY_PROXY}" sudo certbot --email "${EASY_LETSENCRYPT_EMAIL}" --agree-tos --manual-public-ip-logging-ok certonly --manual --preferred-challenges dns -d "${EASY_LETSENCRYPT_DOMAIN},*.${EASY_LETSENCRYPT_DOMAIN}"
   return $?
  fi
  if [[ "certbot-ionos" == "$2" ]]; then
-  local EASY_PROXY=$(easy proxy status)
+  local EASY_PROXY
+  EASY_PROXY=$(easy proxy status)
   if [[ -z "${EASY_PROXY}" ]]; then
    echo "Proxy is not running."
    return 1
@@ -152,7 +153,8 @@ chmod 600 /etc/letsencrypt/ionos.ini"
   return $?
  fi
  if [[ "reload" == "$2" ]]; then
-  local EASY_PROXY=$(easy proxy status)
+  local EASY_PROXY
+  EASY_PROXY=$(easy proxy status)
   if [[ -z "${EASY_PROXY}" ]]; then
    echo "Proxy is not running."
    return 1
@@ -165,7 +167,8 @@ chmod 600 /etc/letsencrypt/ionos.ini"
   return $?
  fi
  if [[ "new" == "$2" ]]; then
-  local EASY_PROXY=$(easy proxy status)
+  local EASY_PROXY
+  EASY_PROXY=$(easy proxy status)
   if [[ -z "${EASY_PROXY}" ]]; then
    echo "Proxy is not running."
    return 1
@@ -179,9 +182,9 @@ chmod 600 /etc/letsencrypt/ionos.ini"
    return 1
   fi
   if [[ "http" == "$3" ]]; then
-   docker exec "${EASY_PROXY}" /usr/local/share/easy/add_subdomain_http $4 $5 $6
+   docker exec "${EASY_PROXY}" /usr/local/share/easy/add_subdomain_http "$4" "$5" "$6"
   elif [[ "https" == "$3" ]]; then
-   docker exec "${EASY_PROXY}" /usr/local/share/easy/add_subdomain_https $4 $5 $6
+   docker exec "${EASY_PROXY}" /usr/local/share/easy/add_subdomain_https "$4" "$5" "$6"
   else
    echo "Invalid protocol $3"
    return 1
@@ -189,43 +192,49 @@ chmod 600 /etc/letsencrypt/ionos.ini"
   return $?
  fi
  if [[ "sh" == "$2" ]]; then
-  local EASY_PROXY=$(easy proxy id)
+  local EASY_PROXY
+  EASY_PROXY=$(easy proxy id)
   docker exec -it "${EASY_PROXY}" bash
   return $?
  fi
  if [[ "log" == "$2" ]]; then
-  local EASY_PROXY=$(easy proxy id)
-  docker logs -f "${EASY_PROXY}" 
+  local EASY_PROXY
+  EASY_PROXY=$(easy proxy id)
+  docker logs -f "${EASY_PROXY}"
   return $?
  fi
  if [[ "destroy" == "$2" ]]; then
-  local EASY_PROXY=$(easy proxy id)
+  local EASY_PROXY
+  EASY_PROXY=$(easy proxy id)
   docker stop "${EASY_PROXY}"
   docker rm "${EASY_PROXY}"
-  rm $EASY_DIR/.id
+  rm "$EASY_DIR/.id"
   return $?
  fi
  if [[ "start" == "$2" ]]; then
-  local EASY_PROXY=$(easy proxy id)
-  docker start "${EASY_PROXY}" 
+  local EASY_PROXY
+  EASY_PROXY=$(easy proxy id)
+  docker start "${EASY_PROXY}"
   return $?
  fi
  if [[ "stop" == "$2" ]]; then
-  local EASY_PROXY=$(easy proxy id)
-  docker stop "${EASY_PROXY}" 
+  local EASY_PROXY
+  EASY_PROXY=$(easy proxy id)
+  docker stop "${EASY_PROXY}"
   return $?
  fi
  if [[ "restart" == "$2" ]]; then
-  local EASY_PROXY=$(easy proxy id)
-  docker restart "${EASY_PROXY}" 
+  local EASY_PROXY
+  EASY_PROXY=$(easy proxy id)
+  docker restart "${EASY_PROXY}"
   return $?
  fi
  if [[ "id" == "$2" ]]; then
-  [[ -f $EASY_DIR/.id ]] && cat $EASY_DIR/.id
+  [[ -f "$EASY_DIR/.id" ]] && cat "$EASY_DIR/.id"
   return $?
  fi
  if [[ "status" == "$2" ]]; then
-  [[ -f $EASY_DIR/.id ]] && easy proxy id >/dev/null && docker ps -q -f id=$(easy proxy id)
+  [[ -f "$EASY_DIR/.id" ]] && easy proxy id >/dev/null && docker ps -q -f "id=$(easy proxy id)"
   return $?
  fi
  if [[ -z "$2" ]]; then
@@ -238,7 +247,8 @@ chmod 600 /etc/letsencrypt/ionos.ini"
 }
 
 function __easy_command_proxy_create {
- local EASY_PROXY=$(easy proxy id)
+ local EASY_PROXY
+ EASY_PROXY=$(easy proxy id)
  if [[ ! -z "${EASY_PROXY}" ]]; then
   echo "There is already an easy proxy instance with docker id ${EASY_PROXY}"
   return 1
@@ -247,15 +257,15 @@ function __easy_command_proxy_create {
   echo "Invalid EASY_LETSENCRYPT_DIR"
   return 1
  fi
- local CONTAINER_ID=$(docker run -d \
- -v ${EASY_DOMAINS_DIR}:/domains \
- -v ${EASY_LETSENCRYPT_DIR}:/etc/letsencrypt \
- -v ${EASY_DIR}/easyhome:/usr/local/share/easy \
+ local CONTAINER_ID
+ if CONTAINER_ID=$(docker run -d \
+ -v "${EASY_DOMAINS_DIR}:/domains" \
+ -v "${EASY_LETSENCRYPT_DIR}:/etc/letsencrypt" \
+ -v "${EASY_DIR}/easyhome:/usr/local/share/easy" \
  -p 80:80 \
  -p 443:443 \
- -t ethiclab/nginx-easy)
- if [[ "$?" == "0" ]]; then
-   echo $CONTAINER_ID > $EASY_DIR/.id
+ -t ethiclab/nginx-easy); then
+   echo "$CONTAINER_ID" > "$EASY_DIR/.id"
  fi
  easy proxy id
 }

--- a/configure-local-devenv
+++ b/configure-local-devenv
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2155
-# Pre-existing finding baselined for incremental ShellCheck adoption — see #8.
-export EASY_HOME=$(pwd)
-export PATH=$EASY_HOME:$PATH
+EASY_HOME=$(pwd)
+export EASY_HOME
+export PATH="$EASY_HOME:$PATH"

--- a/easy
+++ b/easy
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC1001,SC1090,SC2046,SC2086,SC2155,SC2164
-# Pre-existing findings baselined for incremental ShellCheck adoption — see #8.
 DATE=$(which date)
 GDATE=$(which gdate 2>/dev/null)
 if [ -x "$GDATE" ]; then
@@ -8,7 +6,7 @@ if [ -x "$GDATE" ]; then
 fi
 
 function LOG_INFO {
-    >&2 echo "$($DATE +"%F %T.%N") - [INFO ] - $*"
+    >&2 echo "$("$DATE" +"%F %T.%N") - [INFO ] - $*"
 }
 
 if [[ -z "$(which easy)" ]]; then
@@ -16,7 +14,8 @@ if [[ -z "$(which easy)" ]]; then
   exit 1
 fi
 
-export EASY_DIR=$(dirname $(realpath $(which easy)))
+EASY_DIR=$(dirname "$(realpath "$(which easy)")")
+export EASY_DIR
 
 if [[ ! -d "${EASY_DIR}" ]]; then
   LOG_INFO "EASY_DIR=${EASY_DIR} is not valid!"
@@ -35,24 +34,24 @@ function easy_verify_dir {
   fi
 }
 
-easy_verify_dir EASY_LETSENCRYPT_DIR $EASY_LETSENCRYPT_DIR
-easy_verify_dir EASY_DOMAINS_DIR $EASY_DOMAINS_DIR
+easy_verify_dir EASY_LETSENCRYPT_DIR "$EASY_LETSENCRYPT_DIR"
+easy_verify_dir EASY_DOMAINS_DIR "$EASY_DOMAINS_DIR"
 
 D="${EASY_DIR}/commands"
 function __private_easy_usage {
  LOG_INFO "Invalid command: $1"
  LOG_INFO "Available switches are:"
- >&2 printf '\t%s\n' "--version" 
+ >&2 printf '\t%s\n' "--version"
  LOG_INFO "Available commands are:"
- cd $D
+ cd "$D" || return 1
  for f in *; do
   >&2 printf '\t%s\n' "${f%.*}"
  done
 }
 
 function __private_easy_version {
- cat ${EASY_DIR}/package.json \
- | grep \"version\"\: \
+ cat "${EASY_DIR}/package.json" \
+ | grep '"version":' \
  | cut -d ',' -f 1 \
  | cut -d ':' -f 2 \
  | cut -d ' ' -f 2 \
@@ -64,7 +63,7 @@ function easy {
  C="$1"
  # no command provided
  if [[ -z "$C" ]]; then
-  __private_easy_usage $C
+  __private_easy_usage "$C"
   return 1
  fi
  # Check if it is a valid command
@@ -89,7 +88,8 @@ function easy {
   if [[ -f "$C_SH" ]]; then
    C_OK="$C_SH"
 
-   source ${C_SH}
+   # shellcheck source=/dev/null
+   source "${C_SH}"
 
    # Check whether the command
    # exists as an internal
@@ -113,7 +113,7 @@ function easy {
  fi
  # couldn't find the command
  if [[ -z "$C_OK" ]]; then
-  __private_easy_usage $C
+  __private_easy_usage "$C"
   return 1
  fi
 }

--- a/easyhome/add_domain
+++ b/easyhome/add_domain
@@ -1,6 +1,4 @@
 #!/bin/bash
-# shellcheck disable=SC2086
-# Pre-existing finding baselined for incremental ShellCheck adoption — see #8.
 /usr/local/share/easy/skeleton.py \
-  --domain $1 \
-  > /usr/local/share/easy/$1.conf
+  --domain "$1" \
+  > "/usr/local/share/easy/$1.conf"

--- a/easyhome/add_subdomain_http
+++ b/easyhome/add_subdomain_http
@@ -1,12 +1,10 @@
 #!/bin/bash
-# shellcheck disable=SC2086
-# Pre-existing finding baselined for incremental ShellCheck adoption — see #8.
-mkdir -p /domains/$2 || exit 1
-/usr/local/share/easy/skeleton.js -t /usr/local/share/easy/templates/http.default.conf --domain $2 > /domains/$2/http.default.conf
+mkdir -p "/domains/$2" || exit 1
+/usr/local/share/easy/skeleton.js -t /usr/local/share/easy/templates/http.default.conf --domain "$2" > "/domains/$2/http.default.conf"
 /usr/local/share/easy/skeleton.js \
   -t /usr/local/share/easy/templates/http.conf \
-  --server_name $1 \
-  --domain $2 \
+  --server_name "$1" \
+  --domain "$2" \
   --location_path / \
-  --location_target $3 \
-  > /domains/$2/http.$1.conf
+  --location_target "$3" \
+  > "/domains/$2/http.$1.conf"

--- a/easyhome/add_subdomain_https
+++ b/easyhome/add_subdomain_https
@@ -1,12 +1,10 @@
 #!/bin/bash
-# shellcheck disable=SC2086
-# Pre-existing finding baselined for incremental ShellCheck adoption — see #8.
-mkdir -p /domains/$2 || exit 1
-/usr/local/share/easy/skeleton.js -t /usr/local/share/easy/templates/https.default.conf --domain $2 > /domains/$2/https.default.conf
+mkdir -p "/domains/$2" || exit 1
+/usr/local/share/easy/skeleton.js -t /usr/local/share/easy/templates/https.default.conf --domain "$2" > "/domains/$2/https.default.conf"
 /usr/local/share/easy/skeleton.js \
   -t /usr/local/share/easy/templates/https.conf \
-  --server_name $1 \
-  --domain $2 \
+  --server_name "$1" \
+  --domain "$2" \
   --location_path / \
-  --location_target $3 \
-  > /domains/$2/https.$1.conf
+  --location_target "$3" \
+  > "/domains/$2/https.$1.conf"


### PR DESCRIPTION
## Summary

Follow-up to #6. When ShellCheck was introduced, the core CLI had ~60 pre-existing findings; #6 fixed only the real errors and **baselined the rest** with file-level `# shellcheck disable=` directives. This PR **burns down that baseline** — fixing the findings for real and removing every directive.

Done after #7 landed, so the bats suite is a safety net for the `easy`/`proxy.sh` dispatcher changes.

## Changes

| File | Findings fixed |
|---|---|
| `easy` | SC2046/SC2086 (quote command subs, `$EASY_*_DIR` args, `$DATE`), SC2155 (split `export EASY_DIR=$(...)`), SC2164 (`cd "$D" \|\| return 1` — was a latent bug), SC1001 (`grep '"version":'`), SC1090 (`# shellcheck source=/dev/null`) |
| `commands/proxy.sh` | SC2086 (quoting), SC2155 (split `local X=$(...)`), SC2046 (quote `id=$(...)`), SC2124 (`"$*"` instead of `"${@}"`), SC2181 (`if CONTAINER_ID=$(docker run ...)` instead of an indirect `$?` check) |
| `configure-local-devenv` | SC2155 (split `export EASY_HOME=$(pwd)`) |
| `easyhome/add_domain` · `add_subdomain_http` · `add_subdomain_https` | SC2086 (quote `$1`/`$2`/`$3`) |

No `# shellcheck disable=` baseline directives remain.

## Test plan

```
npm run lint    # exits 0, no findings, no baseline directives
bats test/      # 16/16 pass — no behavior regressions
bash -n <each file>   # syntax OK
```

The pre-push hook (lint + bats) passed on push — `git push` now works without `--no-verify`.

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)