### PR TITLE
chore: add LICENSE and trim the npm package for release

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019-2026 EthicLab
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,16 @@
   "name": "@ethiclab/easy-cli",
   "version": "2.0.0",
   "description": "Nginx reverse proxy with Let's Encrypt SSL automation, multi-DNS provider support (IONOS, Route53, Cloudflare, DigitalOcean)",
-  "main": "index.js",
+  "files": [
+    "easy",
+    "commands/",
+    "easyhome/",
+    "Dockerfile",
+    "Dockerfile.build",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
   "scripts": {
     "test": "bats test/",
     "lint": "shellcheck easy configure-local-devenv commands/*.sh easyhome/add_domain easyhome/add_subdomain_http easyhome/add_subdomain_https easyhome/easy-proxy-start easyhome/ionos-config-helper.sh .husky/pre-push"


### PR DESCRIPTION
## Summary

Release-prep for `@ethiclab/easy-cli@2.0.0`: add the missing `LICENSE` file and stop publishing dev cruft to npm.

## Changes

- **`LICENSE`** — add the MIT license file. `package.json` already declared `"license": "MIT"` but no file existed.
- **`package.json`** — add a `files` allowlist. `npm publish` previously shipped **all 66 repo files** (`test/`, `scripts/*.ts`, `bin/`, `.beads/`, `.metaswarm/`, `.github/`, `CLAUDE.md`, internal docs). With the allowlist the package is **26 files / 34 KB** (was 66 / 162 KB) — only runtime files: `easy`, `commands/`, `easyhome/`, the Dockerfiles, and README/CHANGELOG/LICENSE.
- **`package.json`** — drop `main`; this is a CLI, not a library.
- Remove the empty `index.js` (the former `main` target).

## Verification

```
npm pack --dry-run   # 26 files, 34 KB
npm run lint         # exits 0
bats test/           # 20/20
```

## ⚠️ Still blocking a turnkey release (not fixed here)

`easy proxy create` runs `docker run … ethiclab/nginx-easy`, and `easy proxy build` builds it `FROM ethiclab/nginx-certbot:2.0` — **neither image is on a registry**. A fresh `npm install` user must first build the base image manually (`docker build -f Dockerfile.build -t ethiclab/nginx-certbot:2.0 .`); the CLI has no command for it. Resolving this (publish the images, or make `easy proxy build` build the base too) is tracked separately — see CLAUDE.md §9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)