### PR TITLE
docs: refresh STATE.md to reflect current project state

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -1,7 +1,7 @@
 # easy-proxy — STATE.md
 
 > Stato attuale e blocchi del progetto
-> Aggiornato: 2026-04-02
+> Aggiornato: 2026-05-18
 
 ---
 
@@ -9,11 +9,10 @@
 
 | Aspetto | Valore |
 |---------|--------|
-| **Versione** | 2.0.0 (npm: `@ethiclab/easy-cli`) |
+| **Versione** | 2.0.0 (npm `@ethiclab/easy-cli` — pubblicato: ancora `1.0.24`) |
 | **Branch** | `master` |
-| **Ultimo commit** | 2026-04-02 — UC1 completo (IONOS DNS automation) |
 | **Remote** | `git@github.com:ethiclab/easy-proxy.git` |
-| **Base image** | `ethiclab/nginx-certbot:2.0` (locale, da pushare) |
+| **Immagine** | `ethiclab/nginx-easy` — build locale da `Dockerfile` self-contained (`FROM certbot/certbot:latest`) |
 
 ---
 
@@ -21,12 +20,9 @@
 
 | Task | Stato | Note |
 |------|-------|------|
-| **UC1: IONOS DNS automation** | ✅ IMPLEMENTATO | `easy proxy certbot-ionos <domain>` funzionante |
-| **skeleton.py → skeleton.js** | ✅ COMPLETATO | Zero dipendenze, unescape `\$` fix incluso |
-| **Base image v2.0** | ✅ BUILD OK | Da pushare a Docker Hub + ghcr.io |
-| **Test locali UC1** | ✅ PASSATI | container, vhost HTTP/HTTPS, reload, error paths |
+| **Rilascio npm 2.0.0** | 🟡 PENDING | `npm publish` — serve `npm login` sullo scope `@ethiclab` |
+| **Test clean-room install** | 🟡 PIANIFICATO | Install pulito in container Docker, dopo il publish |
 | **Test reale IONOS** | 🔴 PENDING | Richiede API key IONOS in `pass` |
-| **Push Docker Hub** | 🟡 PENDING | `docker push ethiclab/nginx-certbot:2.0` |
 
 ---
 
@@ -34,57 +30,44 @@
 
 | Blocco | Gravità | Next step |
 |--------|---------|-----------|
-| **API key IONOS non ancora in `pass`** | 🔴 BLOCCANTE per test reale | `pass insert ionos/api-key` + `pass insert ionos/api-secret` dalla console IONOS |
-| **Base image non su Docker Hub** | 🟡 MEDIO | `docker login && docker push ethiclab/nginx-certbot:2.0` |
+| **API key IONOS non in `pass`** | 🔴 BLOCCANTE per test reale | `pass insert ionos/api-key` + `pass insert ionos/api-secret` dalla console IONOS |
+
+Nessun blocco tecnico aperto — il bootstrap di build e push è risolto.
 
 ---
 
-## Test completati (2026-04-02)
+## Fatto in questa fase (sessione 2026-05-17/18)
 
-| Test | Risultato |
-|------|-----------|
-| `easy proxy create` — container Up | ✅ |
-| `easy proxy new http` — vhost generato | ✅ |
-| `easy proxy new https` — template corretto (`$upstream` unescapato) | ✅ |
-| `easy proxy reload` con vhost HTTP | ✅ |
-| `easy proxy reload` con vhost HTTPS senza cert | ✅ fallisce come atteso |
-| `easy proxy certbot-ionos` senza dominio | ✅ errore corretto |
-| `easy proxy certbot-ionos` senza credenziali | ✅ errore corretto |
-| `easy proxy destroy` | ✅ |
+Lavoro svolto con metaswarm, una PR per cambiamento:
 
----
+| PR | Cosa |
+|----|------|
+| #9 | Script lint ShellCheck (`npm run lint`) |
+| #11 | Fix workflow CI per progetto Bash/Docker (ShellCheck pinnato a v0.11.0) |
+| #12 | Harness test bats (`test/`, 20 test) + tooling coverage |
+| #13 | Cleanup dei finding ShellCheck baselined (zero direttive `disable`) |
+| #14 | Container identificato per nome `easy-proxy`, non più file `.id` (issue #5) |
+| #15 | README riscritto user-facing + `CHANGELOG.md` |
+| #16 | `LICENSE` (MIT) + `files` allowlist npm (pacchetto 66 → 25 file) |
+| #17 | `Dockerfile` self-contained — un solo build, nessuna immagine base custom |
 
-## Modifiche significative v2.0.0
-
-| File | Modifica |
-|------|----------|
-| `Dockerfile` | `FROM ethiclab/nginx-certbot:1.1` → `2.0` |
-| `Dockerfile.build` | Nuova base image da zero: Alpine + nginx 1.26 + bash + Node 20 + certbot-dns-ionos |
-| `easyhome/skeleton.js` | **NUOVO** — sostituisce skeleton.py (Python 2); zero deps; fix `\$` unescape |
-| `easyhome/nginx.conf` | `user www-data` → `user nginx` (Alpine) |
-| `easyhome/add_subdomain_http/https` | Chiama `skeleton.js` invece di `skeleton.py` |
-| `easyhome/ionos-config-helper.sh` | **NUOVO** — helper per creare `/etc/letsencrypt/ionos.ini` |
-| `commands/proxy.sh` | **NUOVO** `certbot-ionos` subcommand; rimosso `-it` da exec non-interattivi |
-| `package.json` | v1.0.24 → 2.0.0; zero dipendenze npm |
+Tutte le issue aperte (#5–#10) sono chiuse. `git push` passa col pre-push hook (lint + test bats).
 
 ---
 
-## Prossimi step (ordine priorità)
+## Prossimi step
 
-1. **Ottenere API key IONOS** dal pannello → `pass insert ionos/api-key`
-2. **Test reale**: `easy proxy certbot-ionos dev.ethiclab.it`
-3. **Push Docker Hub**: `docker push ethiclab/nginx-certbot:2.0`
-4. **Setup `/etc/hosts`** per test browser con ELEVEN locale
+1. **`npm publish`** — pubblicare `@ethiclab/easy-cli@2.0.0` (azione manuale, `npm login`)
+2. **Test clean-room** — install pulito in un container Docker da zero
+3. **Ottenere API key IONOS** → `pass insert ionos/api-key`
+4. **Test reale**: `easy proxy certbot-ionos dev.ethiclab.it`
 5. **Split-view DNS** con dnsmasq (Phase 2)
 
 ---
 
-## Prossima sessione — handoff
-
-Vedi `.agents/008-easy-proxy-uc1.md` per context completo.
+## Quick resume
 
 ```bash
-# Quick resume:
 cd ~/ethiclab/lab/easy-proxy
 export EASY_DIR="$PWD"
 export EASY_LETSENCRYPT_DIR="$HOME/.easy-proxy/letsencrypt"


### PR DESCRIPTION
## Summary

`STATE.md` was dated `2026-04-02` and predated the entire test-harness / ShellCheck / issue-5 / release-prep / self-contained-build work. It still listed obsolete blockers (e.g. "push the base image to Docker Hub").

Rewrites it to reflect reality as of `2026-05-18`:

- Current version state — `2.0.0`, image built locally from the self-contained `Dockerfile`
- The PRs shipped this phase (#9–#17)
- Remaining items: `npm publish`, the clean-room install test, the real IONOS test
- No open technical blockers

🤖 Generated with [Claude Code](https://claude.com/claude-code)