### PR TITLE
fix: easy --version and proxy help work without runtime env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ A major release: automatic Let's Encrypt SSL with multi-DNS-provider support.
 - `easy proxy create` no longer writes a state file into the install directory.
   After `npm install -g` that directory is root-owned, so non-root users got
   `Permission denied` ([#5]).
+- `easy --version` and `easy proxy help` now work before the runtime env vars
+  (`EASY_LETSENCRYPT_DIR`, `EASY_DOMAINS_DIR`) are set — they no longer fail
+  with `... is not set!`, so a freshly installed CLI can be inspected.
 - Argument quoting hardened across the `easy` dispatcher and `commands/proxy.sh`
   (ShellCheck cleanup).
 

--- a/easy
+++ b/easy
@@ -34,8 +34,16 @@ function easy_verify_dir {
   fi
 }
 
-easy_verify_dir EASY_LETSENCRYPT_DIR "$EASY_LETSENCRYPT_DIR"
-easy_verify_dir EASY_DOMAINS_DIR "$EASY_DOMAINS_DIR"
+# `easy --version` and `easy proxy help` are informational — they need
+# neither EASY_LETSENCRYPT_DIR nor EASY_DOMAINS_DIR. Skip the check for them
+# so a freshly installed CLI can be inspected before those env vars are set.
+case "$1:$2" in
+  --version:* | proxy:help) : ;;
+  *)
+    easy_verify_dir EASY_LETSENCRYPT_DIR "$EASY_LETSENCRYPT_DIR"
+    easy_verify_dir EASY_DOMAINS_DIR "$EASY_DOMAINS_DIR"
+    ;;
+esac
 
 D="${EASY_DIR}/commands"
 function __private_easy_usage {

--- a/test/dispatcher.bats
+++ b/test/dispatcher.bats
@@ -11,6 +11,13 @@ setup() { easy_setup; }
   [ "$output" = "2.0.0" ]
 }
 
+@test "easy --version works without the runtime env vars set" {
+  unset EASY_LETSENCRYPT_DIR EASY_DOMAINS_DIR
+  run easy --version
+  [ "$status" -eq 0 ]
+  [ "$output" = "2.0.0" ]
+}
+
 @test "easy with no command prints usage and fails" {
   run easy
   [ "$status" -eq 1 ]

--- a/test/proxy.bats
+++ b/test/proxy.bats
@@ -18,6 +18,13 @@ setup() { easy_setup; }
   [[ "$output" == *"easy proxy certbot-ionos <domain>"* ]]
 }
 
+@test "easy proxy help works without the runtime env vars set" {
+  unset EASY_LETSENCRYPT_DIR EASY_DOMAINS_DIR
+  run easy proxy help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"easy proxy create"* ]]
+}
+
 @test "easy proxy with an unknown subcommand prints usage and fails" {
   run easy proxy not-a-real-subcommand
   [ "$status" -eq 1 ]


### PR DESCRIPTION
## Problem

`easy` validated `EASY_LETSENCRYPT_DIR` and `EASY_DOMAINS_DIR` at the top of the script, **unconditionally** — before any command runs. So even informational commands failed until those env vars were exported:

```
$ easy --version
... - [INFO ] - EASY_LETSENCRYPT_DIR is not set!     # expected: 2.0.0
```

`easy --version` is the first thing anyone runs after `npm install -g` to confirm the install — a poor first impression. `easy proxy help` had the same issue.

**Found by the pre-publish clean-room test** (clean install of the `npm pack` tarball in a `docker:dind` container).

## Fix

Skip the directory validation for the two informational invocations — `easy --version` and `easy proxy help` — via a `case` on `"$1:$2"`. Every operational command (`create`, `new`, `certbot-ionos`, …) still validates as before.

- **`easy`** — guard the `easy_verify_dir` calls.
- **`test/dispatcher.bats`** — `easy --version` works with the env vars unset.
- **`test/proxy.bats`** — `easy proxy help` works with the env vars unset.
- **`CHANGELOG.md`** — note the fix under `[2.0.0] Fixed`.

## Test plan

TDD — the two tests were written first, watched fail against the old unconditional validation, then made green.

```
npm run lint   # exits 0
bats test/     # 22/22 (was 20 + 2 new)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)