### PR TITLE
chore: post-release cleanup — CHANGELOG date and package.json bin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [2.0.0] — unreleased
+## [2.0.0] — 2026-05-18
 
 A major release: automatic Let's Encrypt SSL with multi-DNS-provider support.
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "shellcheck easy configure-local-devenv commands/*.sh easyhome/add_domain easyhome/add_subdomain_http easyhome/add_subdomain_https easyhome/easy-proxy-start easyhome/ionos-config-helper.sh .husky/pre-push"
   },
   "bin": {
-    "easy": "./easy"
+    "easy": "easy"
   },
   "engines": {
     "node": ">=14.0.0"


### PR DESCRIPTION
## Summary

Two small post-release cleanups after `@ethiclab/easy-cli@2.0.0` was published.

- **`CHANGELOG.md`** — `2.0.0` is live on npm; date the entry `2026-05-18` (was `unreleased`).
- **`package.json`** — `npm pkg fix`: `bin.easy` `"./easy"` → `"easy"`. `npm publish` warned `"bin[easy]" script name was cleaned` — this silences it for future publishes (npm already auto-corrected the published copy).

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)