### PR TITLE
release: 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [2.2.0] — 2026-05-18
 
 ### Added
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # easy-proxy — CLAUDE.md
 
 > Nginx reverse proxy CLI con Let's Encrypt SSL automation e multi-DNS provider.
-> Stato: **ATTIVO** — v2.1.0
+> Stato: **ATTIVO** — v2.2.0
 > Ultimo aggiornamento: 2026-05-18
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethiclab/easy-cli",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Nginx reverse proxy with Let's Encrypt SSL automation, multi-DNS provider support (IONOS, Route53, Cloudflare, DigitalOcean)",
   "files": [
     "easy",

--- a/test/dispatcher.bats
+++ b/test/dispatcher.bats
@@ -8,14 +8,14 @@ setup() { easy_setup; }
 @test "easy --version prints the package.json version" {
   run easy --version
   [ "$status" -eq 0 ]
-  [ "$output" = "2.1.0" ]
+  [ "$output" = "2.2.0" ]
 }
 
 @test "easy --version works without the runtime env vars set" {
   unset EASY_LETSENCRYPT_DIR EASY_DOMAINS_DIR
   run easy --version
   [ "$status" -eq 0 ]
-  [ "$output" = "2.1.0" ]
+  [ "$output" = "2.2.0" ]
 }
 
 @test "easy with no command prints usage and fails" {


### PR DESCRIPTION
## Summary

Cuts the **2.2.0** release. A minor bump on top of `2.1.0` — additive, no breaking changes.

### What's in 2.2.0

- `easy proxy verify` (#27) — health check; `easy proxy create` auto-runs it so it no longer reports success when nginx crashed.
- `easy proxy recover` (#28) — break-glass network recovery with statistical edge-network detection.

## Changes

- `package.json` — `2.1.0` → `2.2.0`.
- `CHANGELOG.md` — date the `[2.2.0]` section (was `[Unreleased]`).
- `test/dispatcher.bats` — expected `easy --version` output → `2.2.0`.
- `CLAUDE.md` — header version.

## Test plan

```
npm run lint   # exits 0
bats test/     # 49/49
npm pack --dry-run   # version 2.2.0, 25 files
```

## After merge

1. (recommended) pre-publish clean-room test of the `npm pack` tarball.
2. `npm publish` from the updated `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)