### PR TITLE
feat: EASY_PROXY_DOCKER_RUN_OPTS — extra docker run options (#32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- `EASY_PROXY_DOCKER_RUN_OPTS` — extra options passed through to the `docker run`
+  of `easy proxy create` (extra published ports, resource limits, etc.).
+
 ## [2.2.0] — 2026-05-18
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,10 @@ Opzionale — `EASY_PROXY_NETWORK`: se impostata, `easy proxy create` aggancia i
 container a quella rete Docker (creata se non esiste) e ricrearlo non perde la
 connettività verso i backend. I siti si collegano con `easy proxy attach`.
 
+Opzionale — `EASY_PROXY_DOCKER_RUN_OPTS`: opzioni extra passate al `docker run`
+di `easy proxy create` (porte aggiuntive, limiti di risorse, ecc.). Es:
+`export EASY_PROXY_DOCKER_RUN_OPTS="-p 8089:8089"`.
+
 ### Build immagine locale
 
 Il `Dockerfile` è self-contained (`FROM certbot/certbot:latest`): un solo build,

--- a/commands/proxy.sh
+++ b/commands/proxy.sh
@@ -368,6 +368,9 @@ function __easy_command_proxy_create {
   fi
   network_args=(--network "${EASY_PROXY_NETWORK}")
  fi
+ # Extra `docker run` options the operator wants (extra ports, limits, ...).
+ local run_opts=()
+ read -ra run_opts <<< "${EASY_PROXY_DOCKER_RUN_OPTS}"
  docker run -d \
  --name "${EASY_PROXY_NAME}" \
  "${network_args[@]}" \
@@ -376,6 +379,7 @@ function __easy_command_proxy_create {
  -v "${EASY_DIR}/easyhome:/usr/local/share/easy" \
  -p 80:80 \
  -p 443:443 \
+ "${run_opts[@]}" \
  -t ethiclab/nginx-easy || return $?
  # `docker run` only starts the container — nginx can still crash on a bad
  # config. Give it a moment, then verify the proxy is actually serving.

--- a/test/create.bats
+++ b/test/create.bats
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats
+# Tests for `easy proxy create` configuration knobs.
+
+load test_helper
+
+setup() { easy_setup; }
+
+@test "easy proxy create passes EASY_PROXY_DOCKER_RUN_OPTS to docker run" {
+  export EASY_PROXY_DOCKER_RUN_OPTS="-p 8089:8089"
+  export DOCKER_LOG="$BATS_TEST_TMPDIR/docker.log"
+  export DOCKER_PROXY_HEALTHY=1
+  mock_docker_lifecycle
+  run easy proxy create
+  [ "$status" -eq 0 ]
+  grep -q -- "-p 8089:8089" "$DOCKER_LOG"
+}
+
+@test "easy proxy create passes multiple EASY_PROXY_DOCKER_RUN_OPTS tokens" {
+  export EASY_PROXY_DOCKER_RUN_OPTS="-p 8089:8089 --memory 512m"
+  export DOCKER_LOG="$BATS_TEST_TMPDIR/docker.log"
+  export DOCKER_PROXY_HEALTHY=1
+  mock_docker_lifecycle
+  run easy proxy create
+  [ "$status" -eq 0 ]
+  grep -q -- "-p 8089:8089" "$DOCKER_LOG"
+  grep -q -- "--memory 512m" "$DOCKER_LOG"
+}
+
+@test "easy proxy create works with EASY_PROXY_DOCKER_RUN_OPTS unset" {
+  export DOCKER_LOG="$BATS_TEST_TMPDIR/docker.log"
+  export DOCKER_PROXY_HEALTHY=1
+  mock_docker_lifecycle
+  run easy proxy create
+  [ "$status" -eq 0 ]
+  grep -q "run -d" "$DOCKER_LOG"
+}

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -27,7 +27,7 @@ easy_setup() {
   export PATH="$MOCK_BIN:$EASY_CLI_DIR:$PATH"
 
   # Deterministic: never inherit real credentials/config from the host shell.
-  unset IONOS_API_KEY IONOS_API_SECRET EASY_LETSENCRYPT_EMAIL EASY_LETSENCRYPT_DOMAIN EASY_PROXY_NETWORK
+  unset IONOS_API_KEY IONOS_API_SECRET EASY_LETSENCRYPT_EMAIL EASY_LETSENCRYPT_DOMAIN EASY_PROXY_NETWORK EASY_PROXY_DOCKER_RUN_OPTS
   # Skip the post-create verify wait — the mocks settle instantly.
   export EASY_VERIFY_DELAY=0
 }


### PR DESCRIPTION
## Problem

`easy proxy create` ran a fixed `docker run` — `--name`, the volumes, `-p 80:80 -p 443:443`, the image. No way to add extra options: extra published ports (e.g. `-p 8089:8089`), resource limits, etc. Operators set `EASY_PROXY_DOCKER_RUN_OPTS` in their profile expecting it to be honoured — but the CLI never read it, so it was silently ignored.

## Fix

`easy proxy create` splices `$EASY_PROXY_DOCKER_RUN_OPTS` (word-split) into the `docker run`, before the image:

```bash
export EASY_PROXY_DOCKER_RUN_OPTS="-p 8089:8089"
easy proxy create   # → docker run -d --name easy-proxy ... -p 8089:8089 -t ethiclab/nginx-easy
```

Unset → behaviour unchanged.

## Changes

- `commands/proxy.sh` — `create` reads `EASY_PROXY_DOCKER_RUN_OPTS` via `read -ra` into an array spliced into the `docker run`.
- `test/create.bats` — 3 tests (single opt, multiple opts, unset); `test_helper.bash` unsets the var for test isolation.
- `CLAUDE.md`, `CHANGELOG.md` updated.

## Test plan

TDD — tests written first, watched fail, then made green.

```
npm run lint   # exits 0
bats test/     # 52/52 (49 + 3 new)
```

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)